### PR TITLE
Fix: Use BlockLootProvider API instead of deprecated LootDropProvider

### DIFF
--- a/src/main/java/org/betterx/datagen/betterend/recipes/EndBlockLootTableProvider.java
+++ b/src/main/java/org/betterx/datagen/betterend/recipes/EndBlockLootTableProvider.java
@@ -1,28 +1,20 @@
 package org.betterx.datagen.betterend.recipes;
 
-import org.betterx.bclib.api.v3.datagen.LootDropProvider;
+import org.betterx.betterend.registry.EndBlocks;
 import org.betterx.wover.core.api.ModCore;
 import org.betterx.wover.datagen.api.provider.WoverLootTableProvider;
 
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 
-import java.util.List;
 import java.util.function.BiConsumer;
 import org.jetbrains.annotations.NotNull;
 
 public class EndBlockLootTableProvider extends WoverLootTableProvider {
-    private final List<String> modIDs;
-
     public EndBlockLootTableProvider(ModCore modCore) {
         super(modCore, "BetterEnd Block Loot", LootContextParamSets.BLOCK);
-        this.modIDs = List.of(modCore.modId);
     }
 
     @Override
@@ -30,22 +22,11 @@ public class EndBlockLootTableProvider extends WoverLootTableProvider {
             @NotNull HolderLookup.Provider lookup,
             @NotNull BiConsumer<ResourceKey<LootTable>, LootTable.Builder> biConsumer
     ) {
-        for (Block block : BuiltInRegistries.BLOCK) {
-            if (block instanceof LootDropProvider dropper) {
-                ResourceLocation id = BuiltInRegistries.BLOCK.getKey(block);
-                if (id != null && shouldInclude(id)) {
-                    LootTable.Builder builder = LootTable.lootTable();
-                    dropper.getDroppedItemsBCL(builder);
-                    biConsumer.accept(
-                            ResourceKey.create(Registries.LOOT_TABLE, id.withPrefix("block/")),
-                            builder
-                    );
-                }
-            }
-        }
-    }
-
-    private boolean shouldInclude(ResourceLocation id) {
-        return modIDs == null || modIDs.isEmpty() || modIDs.contains(id.getNamespace());
+        // Ensure blocks are loaded before generating loot tables
+        EndBlocks.ensureStaticallyLoaded();
+        
+        // Use BlockRegistry.bootstrapBlockLoot() which automatically handles
+        // all blocks implementing BlockLootProvider (including BaseOreBlock)
+        EndBlocks.getBlockRegistry().bootstrapBlockLoot(lookup, biConsumer);
     }
 }


### PR DESCRIPTION
This fixes the issue where ore blocks (thallasium, amber, ender) were not dropping items when mined, only experience.

The problem was that EndBlockLootTableProvider was using the deprecated LootDropProvider API (BCLib v3), but BaseOreBlock implements BlockLootProvider (WorldWeaver API). Since BaseOreBlock doesn't implement LootDropProvider, ore blocks were never found and their loot tables were never generated.

The fix uses BlockRegistry.bootstrapBlockLoot() which automatically handles all blocks implementing BlockLootProvider, including BaseOreBlock and all other BetterEnd blocks.

This change:
- Removes dependency on deprecated LootDropProvider API
- Uses the correct BlockLootProvider API from WorldWeaver
- Automatically generates loot tables for all blocks registered via BlockRegistry
- Fixes ore drops for thallasium, amber, and ender ores