### PR TITLE
Partial compatibility with Concurrent Chunk Management Engine (C2ME)

### DIFF
--- a/src/main/java/org/betterx/betterend/world/structures/piece/LakePiece.java
+++ b/src/main/java/org/betterx/betterend/world/structures/piece/LakePiece.java
@@ -40,7 +40,7 @@ import java.util.Map;
 public class LakePiece extends BasePiece {
     private static final BlockState ENDSTONE = Blocks.END_STONE.defaultBlockState();
     private static final BlockState WATER = Blocks.WATER.defaultBlockState();
-    private final Map<Integer, Byte> heightmap = Maps.newHashMap();
+    private final Map<Integer, Byte> heightmap = Maps.newConcurrentMap();
     private OpenSimplexNoise noise;
     private BlockPos center;
     private float radius;

--- a/src/main/java/org/betterx/betterend/world/structures/piece/MountainPiece.java
+++ b/src/main/java/org/betterx/betterend/world/structures/piece/MountainPiece.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Maps;
 import java.util.Map;
 
 public abstract class MountainPiece extends BasePiece {
-    protected Map<Integer, Integer> heightmap = Maps.newHashMap();
+    protected Map<Integer, Integer> heightmap = Maps.newConcurrentMap();
     protected OpenSimplexNoise noise1;
     protected OpenSimplexNoise noise2;
     protected BlockPos center;


### PR DESCRIPTION
This patch updates `MountainPiece` and `LakePiece` to cache their heightmaps using `ConcurrentHashMap` instead of a single threaded `HashMap`. When running with C2ME and `AllowThreadedFeatures` enabled, Crystal Mountain and Megalake features may be generated on worker threads, causing off-thread writes to the heightmap cache and resulting in crashes. Using a thread-safe map resolves this issue and allows BetterEnd to run with C2ME without disabling `AllowThreadedFeatures`.

There is a separate, unrelated crash that can still occur when features generate across chunk borders. This has not been fully investigated yet, but disabling C2ME’s `EndBiomeCache` appears to prevent it. Compared to disabling `AllowThreadedFeatures`, this is a better tradeoff due to the a much smaller performance impact.

In terms of worldgen parity, BetterEnd behaves identically with or without this patch when run alone. When used alongside C2ME, very small differences may occur as a result of multithreaded feature generation but not enough to be a concern.
