### PR TITLE
Only use Bark wood variant for trees

### DIFF
--- a/src/main/java/org/betterx/betterend/world/features/trees/DragonTreeFeature.java
+++ b/src/main/java/org/betterx/betterend/world/features/trees/DragonTreeFeature.java
@@ -220,7 +220,7 @@ public class DragonTreeFeature extends DefaultFeature {
     private static Function<PosInfo, BlockState> postProcessFunc() {
         return (info) -> {
             if (EndBlocks.DRAGON_TREE.isTreeLog(info.getStateUp()) && EndBlocks.DRAGON_TREE.isTreeLog(info.getStateDown())) {
-                return EndBlocks.DRAGON_TREE.getLog().defaultBlockState();
+                return EndBlocks.DRAGON_TREE.getBark().defaultBlockState();
             }
             return info.getState();
         };

--- a/src/main/java/org/betterx/betterend/world/features/trees/HelixTreeFeature.java
+++ b/src/main/java/org/betterx/betterend/world/features/trees/HelixTreeFeature.java
@@ -104,7 +104,7 @@ public class HelixTreeFeature extends DefaultFeature {
         SplineHelper.fillSplineForce(
                 spline2,
                 world,
-                EndBlocks.HELIX_TREE.getLog().defaultBlockState(),
+                EndBlocks.HELIX_TREE.getBark().defaultBlockState(),
                 leafStart,
                 BlockBehaviour.BlockStateBase::canBeReplaced
         );
@@ -212,7 +212,7 @@ public class HelixTreeFeature extends DefaultFeature {
     private Function<PosInfo, BlockState> postProcessFunc() {
         return (info) -> {
             if (EndBlocks.HELIX_TREE.isTreeLog(info.getStateUp()) && EndBlocks.HELIX_TREE.isTreeLog(info.getStateDown())) {
-                return EndBlocks.HELIX_TREE.getLog().defaultBlockState();
+                return EndBlocks.HELIX_TREE.getBark().defaultBlockState();
             }
             return info.getState();
         };

--- a/src/main/java/org/betterx/betterend/world/features/trees/JellyshroomFeature.java
+++ b/src/main/java/org/betterx/betterend/world/features/trees/JellyshroomFeature.java
@@ -58,7 +58,7 @@ public class JellyshroomFeature extends DefaultFeature {
         sdf.setReplaceFunction(REPLACE).addPostProcess((info) -> {
             if (EndBlocks.JELLYSHROOM.isTreeLog(info.getState())) {
                 if (EndBlocks.JELLYSHROOM.isTreeLog(info.getStateUp()) && EndBlocks.JELLYSHROOM.isTreeLog(info.getStateDown())) {
-                    return EndBlocks.JELLYSHROOM.getLog().defaultBlockState();
+                    return EndBlocks.JELLYSHROOM.getBark().defaultBlockState();
                 }
             } else if (info.getState().is(EndBlocks.JELLYSHROOM_CAP_PURPLE)) {
                 float dx = info.getPos().getX() - pos.getX() - last.x();

--- a/src/main/java/org/betterx/betterend/world/features/trees/LacugroveFeature.java
+++ b/src/main/java/org/betterx/betterend/world/features/trees/LacugroveFeature.java
@@ -97,7 +97,7 @@ public class LacugroveFeature extends DefaultFeature {
                                 BlocksHelper.setWithoutUpdate(
                                         world,
                                         mut,
-                                        y == top ? EndBlocks.LACUGROVE.getBark() : EndBlocks.LACUGROVE.getLog()
+                                        y == top ? EndBlocks.LACUGROVE.getBark() : EndBlocks.LACUGROVE.getBark()
                                 );
                             } else {
                                 break;
@@ -210,7 +210,7 @@ public class LacugroveFeature extends DefaultFeature {
     private Function<PosInfo, BlockState> postProcessFunc() {
         return (info) -> {
             if (EndBlocks.LACUGROVE.isTreeLog(info.getStateUp()) && EndBlocks.LACUGROVE.isTreeLog(info.getStateDown())) {
-                return EndBlocks.LACUGROVE.getLog().defaultBlockState();
+                return EndBlocks.LACUGROVE.getBark().defaultBlockState();
             }
             return info.getState();
         };

--- a/src/main/java/org/betterx/betterend/world/features/trees/MossyGlowshroomFeature.java
+++ b/src/main/java/org/betterx/betterend/world/features/trees/MossyGlowshroomFeature.java
@@ -59,7 +59,7 @@ public class MossyGlowshroomFeature extends DefaultFeature {
         List<Vector3f> spline = SplineHelper.makeSpline(0, 0, 0, 0, height, 0, count);
         SplineHelper.offsetParts(spline, random, 1F, 0, 1F);
         SDF sdf = SplineHelper.buildSDF(spline, 2.1F, 1.5F, (pos) -> {
-            return EndBlocks.MOSSY_GLOWSHROOM.getLog().defaultBlockState();
+            return EndBlocks.MOSSY_GLOWSHROOM.getBark().defaultBlockState();
         });
         Vector3f pos = spline.get(spline.size() - 1);
         float scale = MHelper.randRange(0.75F, 1.1F, random);

--- a/src/main/java/org/betterx/betterend/world/features/trees/PythadendronTreeFeature.java
+++ b/src/main/java/org/betterx/betterend/world/features/trees/PythadendronTreeFeature.java
@@ -212,7 +212,7 @@ public class PythadendronTreeFeature extends DefaultFeature {
     private static Function<PosInfo, BlockState> postProcessFunc() {
         return (info) -> {
             if (EndBlocks.PYTHADENDRON.isTreeLog(info.getStateUp()) && EndBlocks.PYTHADENDRON.isTreeLog(info.getStateDown())) {
-                return EndBlocks.PYTHADENDRON.getLog().defaultBlockState();
+                return EndBlocks.PYTHADENDRON.getBark().defaultBlockState();
             }
             return info.getState();
         };

--- a/src/main/java/org/betterx/betterend/world/features/trees/UmbrellaTreeFeature.java
+++ b/src/main/java/org/betterx/betterend/world/features/trees/UmbrellaTreeFeature.java
@@ -104,7 +104,7 @@ public class UmbrellaTreeFeature extends DefaultFeature {
 
         sdf.setReplaceFunction(replaceFunc()).addPostProcess((info) -> {
             if (EndBlocks.UMBRELLA_TREE.isTreeLog(info.getStateUp()) && EndBlocks.UMBRELLA_TREE.isTreeLog(info.getStateDown())) {
-                return EndBlocks.UMBRELLA_TREE.getLog().defaultBlockState();
+                return EndBlocks.UMBRELLA_TREE.getBark().defaultBlockState();
             } else if (info.getState().equals(membrane)) {
                 Center min = centers.get(0);
                 double d = Double.MAX_VALUE;

--- a/src/main/java/org/betterx/betterend/world/structures/features/GiantMossyGlowshroomStructure.java
+++ b/src/main/java/org/betterx/betterend/world/structures/features/GiantMossyGlowshroomStructure.java
@@ -87,7 +87,7 @@ public class GiantMossyGlowshroomStructure extends SDFStructureFeature {
         List<Vector3f> spline = SplineHelper.makeSpline(0, 0, 0, 0, height, 0, count);
         SplineHelper.offsetParts(spline, random, 1F, 0, 1F);
         SDF sdf = SplineHelper.buildSDF(spline, 2.1F, 1.5F, (pos) -> {
-            return EndBlocks.MOSSY_GLOWSHROOM.getLog().defaultBlockState();
+            return EndBlocks.MOSSY_GLOWSHROOM.getBark().defaultBlockState();
         });
         Vector3f pos = spline.get(spline.size() - 1);
         float scale = MHelper.randRange(2F, 3.5F, random);


### PR DESCRIPTION
Fixes issues with veinmine/ultimine where the feature will not detect the tree properly due to some blocks being barks and others being logs. There were no visual impacts to the trees as a result.