### PR TITLE
Improve C2ME worldgen thread safety

### DIFF
--- a/src/main/java/org/betterx/betterend/world/features/BiomeIslandFeature.java
+++ b/src/main/java/org/betterx/betterend/world/features/BiomeIslandFeature.java
@@ -10,7 +10,6 @@ import org.betterx.betterend.noise.OpenSimplexNoise;
 import org.betterx.betterend.world.biome.EndBiome;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.BlockPos.MutableBlockPos;
 import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
@@ -18,13 +17,6 @@ import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
 import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
 
 public class BiomeIslandFeature extends DefaultFeature {
-    private static final MutableBlockPos CENTER = new MutableBlockPos();
-    private static final SDF ISLAND;
-
-    private static OpenSimplexNoise simplexNoise = new OpenSimplexNoise(412L);
-    private static BlockState topBlock = Blocks.GRASS_BLOCK.defaultBlockState();
-    private static BlockState underBlock = Blocks.DIRT.defaultBlockState();
-
     @Override
     public boolean place(FeaturePlaceContext<NoneFeatureConfiguration> featureConfig) {
         final BlockPos pos = featureConfig.origin();
@@ -34,23 +26,29 @@ public class BiomeIslandFeature extends DefaultFeature {
         BlockPos surfacePos = new BlockPos(pos.getX(), pos.getY() - dist, pos.getZ());
         BlockState topMaterial = EndBiome.findTopMaterial(world, surfacePos);
 
+        BlockState topBlock;
+        BlockState underBlock;
         if (BlocksHelper.isFluid(topMaterial)) {
             topBlock = Blocks.GRAVEL.defaultBlockState();
             underBlock = Blocks.STONE.defaultBlockState();
         } else {
+            topBlock = topMaterial;
             underBlock = EndBiome.findUnderMaterial(world, surfacePos);
         }
 
-        simplexNoise = new OpenSimplexNoise(world.getSeed());
-        CENTER.set(pos);
-        ISLAND.fillRecursive(world, pos.below());
+        createSDFIsland(pos, new OpenSimplexNoise(world.getSeed()), topBlock, underBlock).fillRecursive(world, pos.below());
         return true;
     }
 
-    private static SDF createSDFIsland() {
+    private static SDF createSDFIsland(
+            BlockPos center,
+            OpenSimplexNoise simplexNoise,
+            BlockState topBlock,
+            BlockState underBlock
+    ) {
         SDF sdfCone = new SDFCappedCone().setRadius1(0).setRadius2(6).setHeight(4).setBlock(pos -> {
-            if (pos.getY() > CENTER.getY()) return AIR;
-            if (pos.getY() == CENTER.getY()) return topBlock;
+            if (pos.getY() > center.getY()) return AIR;
+            if (pos.getY() == center.getY()) return topBlock;
             return underBlock;
         });
         sdfCone = new SDFTranslate().setTranslate(0, -2, 0).setSource(sdfCone);
@@ -59,14 +57,10 @@ public class BiomeIslandFeature extends DefaultFeature {
                                            float deltaY = Math.abs(pos.y());
                                            float deltaZ = Math.abs(pos.z());
                                            if (deltaY < 2.0f && (deltaX < 3.0f || deltaZ < 3.0F)) return 0.0f;
-                                           return (float) simplexNoise.eval(CENTER.getX() + pos.x(), CENTER.getY() + pos.y(), CENTER.getZ() + pos.z());
+                                           return (float) simplexNoise.eval(center.getX() + pos.x(), center.getY() + pos.y(), center.getZ() + pos.z());
                                        })
                                        .setSource(sdfCone)
                                        .setReplaceFunction(state -> BlocksHelper.isFluid(state) || state.canBeReplaced());
         return sdfCone;
-    }
-
-    static {
-        ISLAND = createSDFIsland();
     }
 }

--- a/src/main/java/org/betterx/betterend/world/features/terrain/OreLayerFeature.java
+++ b/src/main/java/org/betterx/betterend/world/features/terrain/OreLayerFeature.java
@@ -31,7 +31,8 @@ public class OreLayerFeature extends Feature<OreLayerFeatureConfig> {
         int posY = MHelper.randRange(cfg.minY, cfg.maxY, random);
 
 
-        SDFSphere sphere = new SDFSphere().setRadius(radius).setBlock(cfg.state);
+        SDFSphere sphere = new SDFSphere().setRadius(radius);
+        sphere.setBlock(cfg.state);
         SDFCoordModify noise = new SDFCoordModify().setFunction((vec) -> {
             double x = (vec.x() + pos.getX()) * 0.1;
             double z = (vec.z() + pos.getZ()) * 0.1;

--- a/src/main/java/org/betterx/betterend/world/features/terrain/OreLayerFeature.java
+++ b/src/main/java/org/betterx/betterend/world/features/terrain/OreLayerFeature.java
@@ -14,11 +14,6 @@ import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
 
 public class OreLayerFeature extends Feature<OreLayerFeatureConfig> {
-    private static final SDFSphere SPHERE;
-    private static final SDFCoordModify NOISE;
-    private static final SDF FUNCTION;
-
-
     public OreLayerFeature() {
         super(OreLayerFeatureConfig.CODEC);
     }
@@ -36,28 +31,19 @@ public class OreLayerFeature extends Feature<OreLayerFeatureConfig> {
         int posY = MHelper.randRange(cfg.minY, cfg.maxY, random);
 
 
-        SPHERE.setRadius(radius).setBlock(cfg.state);
-        NOISE.setFunction((vec) -> {
+        SDFSphere sphere = new SDFSphere().setRadius(radius).setBlock(cfg.state);
+        SDFCoordModify noise = new SDFCoordModify().setFunction((vec) -> {
             double x = (vec.x() + pos.getX()) * 0.1;
             double z = (vec.z() + pos.getZ()) * 0.1;
             double offset = cfg.getNoise(world.getSeed()).eval(x, z);
             vec.set(vec.x(), vec.y() + (float) offset * 8, vec.z());
         });
-        FUNCTION.fillRecursive(world, new BlockPos(posX, posY, posZ));
-        return true;
-    }
-
-    static {
-        SPHERE = new SDFSphere();
-        NOISE = new SDFCoordModify();
-
-        SDF body = SPHERE;
-        body = new SDFScale3D().setScale(1, 0.2F, 1).setSource(body);
-        body = NOISE.setSource(body);
-        body.setReplaceFunction((state) -> {
+        SDF function = new SDFScale3D().setScale(1, 0.2F, 1).setSource(sphere);
+        function = noise.setSource(function);
+        function.setReplaceFunction((state) -> {
             return state.is(Blocks.END_STONE);
         });
-
-        FUNCTION = body;
+        function.fillRecursive(world, new BlockPos(posX, posY, posZ));
+        return true;
     }
 }

--- a/src/main/java/org/betterx/betterend/world/features/terrain/OreLayerFeatureConfig.java
+++ b/src/main/java/org/betterx/betterend/world/features/terrain/OreLayerFeatureConfig.java
@@ -21,7 +21,7 @@ public class OreLayerFeatureConfig implements FeatureConfiguration {
     public final float radius;
     public final int minY;
     public final int maxY;
-    private OpenSimplexNoise noise;
+    private volatile OpenSimplexNoise noise;
 
     public OreLayerFeatureConfig(BlockState state, float radius, int minY, int maxY) {
         this.state = state;
@@ -31,9 +31,16 @@ public class OreLayerFeatureConfig implements FeatureConfiguration {
     }
 
     public OpenSimplexNoise getNoise(long seed) {
-        if (noise == null) {
-            noise = new OpenSimplexNoise(seed);
+        OpenSimplexNoise localNoise = noise;
+        if (localNoise == null) {
+            synchronized (this) {
+                localNoise = noise;
+                if (localNoise == null) {
+                    localNoise = new OpenSimplexNoise(seed);
+                    noise = localNoise;
+                }
+            }
         }
-        return noise;
+        return localNoise;
     }
 }

--- a/src/main/java/org/betterx/betterend/world/features/trees/MossyGlowshroomFeature.java
+++ b/src/main/java/org/betterx/betterend/world/features/trees/MossyGlowshroomFeature.java
@@ -29,15 +29,6 @@ import java.util.function.Function;
 
 public class MossyGlowshroomFeature extends DefaultFeature {
     private static final Function<BlockState, Boolean> REPLACE;
-    private static final Vector3f CENTER = new Vector3f();
-    private static final SDFBinary FUNCTION;
-    private static final SDFTranslate HEAD_POS;
-    private static final SDFFlatWave ROOTS_ROT;
-
-    private static final SDFPrimitive CONE1;
-    private static final SDFPrimitive CONE2;
-    private static final SDFPrimitive CONE_GLOW;
-    private static final SDFPrimitive ROOTS;
 
     @Override
     public boolean place(FeaturePlaceContext<NoneFeatureConfiguration> featureConfig) {
@@ -48,11 +39,6 @@ public class MossyGlowshroomFeature extends DefaultFeature {
         if (!state.getFluidState().isEmpty()) return false;
         BlockState down = world.getBlockState(blockPos.below());
         if (!down.is(EndBlocks.END_MYCELIUM) && !down.is(EndBlocks.END_MOSS)) return false;
-
-        CONE1.setBlock(EndBlocks.MOSSY_GLOWSHROOM_CAP);
-        CONE2.setBlock(EndBlocks.MOSSY_GLOWSHROOM_CAP);
-        CONE_GLOW.setBlock(EndBlocks.MOSSY_GLOWSHROOM_HYMENOPHORE);
-        ROOTS.setBlock(EndBlocks.MOSSY_GLOWSHROOM.getBark());
 
         float height = MHelper.randRange(10F, 25F, random);
         int count = MHelper.floor(height / 4);
@@ -69,12 +55,8 @@ public class MossyGlowshroomFeature extends DefaultFeature {
         }
         BlocksHelper.setWithoutUpdate(world, blockPos, AIR);
 
-        CENTER.set(blockPos.getX(), 0, blockPos.getZ());
-        HEAD_POS.setTranslate(pos.x(), pos.y(), pos.z());
-        ROOTS_ROT.setAngle(random.nextFloat() * MHelper.PI2);
-        FUNCTION.setSourceA(sdf);
-
-        new SDFScale().setScale(scale).setSource(FUNCTION).setReplaceFunction(REPLACE).addPostProcess((info) -> {
+        SDF function = createFunction(blockPos, pos, sdf, random.nextFloat() * MHelper.PI2);
+        new SDFScale().setScale(scale).setSource(function).setReplaceFunction(REPLACE).addPostProcess((info) -> {
             if (EndBlocks.MOSSY_GLOWSHROOM.isTreeLog(info.getState())) {
                 if (random.nextBoolean() && info.getStateUp().getBlock() == EndBlocks.MOSSY_GLOWSHROOM_CAP) {
                     info.setState(EndBlocks.MOSSY_GLOWSHROOM_CAP.defaultBlockState()
@@ -117,9 +99,12 @@ public class MossyGlowshroomFeature extends DefaultFeature {
         return true;
     }
 
-    static {
+    private SDF createFunction(BlockPos center, Vector3f headPosition, SDF trunk, float rootsAngle) {
         SDFCappedCone cone1 = new SDFCappedCone().setHeight(2.5F).setRadius1(1.5F).setRadius2(2.5F);
         SDFCappedCone cone2 = new SDFCappedCone().setHeight(3F).setRadius1(2.5F).setRadius2(13F);
+        cone1.setBlock(EndBlocks.MOSSY_GLOWSHROOM_CAP);
+        cone2.setBlock(EndBlocks.MOSSY_GLOWSHROOM_CAP);
+
         SDF posedCone2 = new SDFTranslate().setTranslate(0, 5, 0).setSource(cone2);
         SDF posedCone3 = new SDFTranslate().setTranslate(0, 12F, 0)
                                            .setSource(new SDFScale().setScale(2).setSource(cone2));
@@ -127,15 +112,12 @@ public class MossyGlowshroomFeature extends DefaultFeature {
         SDF wave = new SDFFlatWave().setRaysCount(12).setIntensity(1.3F).setSource(upCone);
         SDF cones = new SDFSmoothUnion().setRadius(3).setSourceA(cone1).setSourceB(wave);
 
-        CONE1 = cone1;
-        CONE2 = cone2;
-
         SDF innerCone = new SDFTranslate().setTranslate(0, 1.25F, 0).setSource(upCone);
         innerCone = new SDFScale3D().setScale(1.2F, 1F, 1.2F).setSource(innerCone);
         cones = new SDFUnion().setSourceA(cones).setSourceB(innerCone);
 
         SDF glowCone = new SDFCappedCone().setHeight(3F).setRadius1(2F).setRadius2(12.5F);
-        CONE_GLOW = (SDFPrimitive) glowCone;
+        ((SDFPrimitive) glowCone).setBlock(EndBlocks.MOSSY_GLOWSHROOM_HYMENOPHORE);
         glowCone = new SDFTranslate().setTranslate(0, 4.25F, 0).setSource(glowCone);
         glowCone = new SDFSubtraction().setSourceA(glowCone).setSourceB(posedCone3);
 
@@ -145,23 +127,26 @@ public class MossyGlowshroomFeature extends DefaultFeature {
         cones = new SDFCoordModify().setFunction((pos) -> {
             float dist = MHelper.length(pos.x(), pos.z());
             float y = pos.y() + (float) noise.eval(
-                    pos.x() * 0.1 + CENTER.x(),
-                    pos.z() * 0.1 + CENTER.z()
+                    pos.x() * 0.1 + center.getX(),
+                    pos.z() * 0.1 + center.getZ()
             ) * dist * 0.3F - dist * 0.15F;
             pos.set(pos.x(), y, pos.z());
         }).setSource(cones);
 
-        HEAD_POS = (SDFTranslate) new SDFTranslate().setSource(new SDFTranslate().setTranslate(0, 2.5F, 0)
-                                                                                 .setSource(cones));
+        SDF headPos = new SDFTranslate().setTranslate(headPosition.x(), headPosition.y(), headPosition.z())
+                                        .setSource(new SDFTranslate().setTranslate(0, 2.5F, 0).setSource(cones));
 
         SDF roots = new SDFSphere().setRadius(4F);
-        ROOTS = (SDFPrimitive) roots;
+        ((SDFPrimitive) roots).setBlock(EndBlocks.MOSSY_GLOWSHROOM.getBark());
         roots = new SDFScale3D().setScale(1, 0.7F, 1).setSource(roots);
-        ROOTS_ROT = (SDFFlatWave) new SDFFlatWave().setRaysCount(5).setIntensity(1.5F).setSource(roots);
+        SDF rootsRot = new SDFFlatWave().setRaysCount(5).setIntensity(1.5F).setAngle(rootsAngle).setSource(roots);
 
-        FUNCTION = new SDFSmoothUnion().setRadius(4)
-                                       .setSourceB(new SDFUnion().setSourceA(HEAD_POS).setSourceB(ROOTS_ROT));
+        return new SDFSmoothUnion().setRadius(4)
+                                   .setSourceA(trunk)
+                                   .setSourceB(new SDFUnion().setSourceA(headPos).setSourceB(rootsRot));
+    }
 
+    static {
         REPLACE = BlocksHelper::replaceableOrPlant;
     }
 }

--- a/src/main/java/org/betterx/betterend/world/structures/piece/CrystalMountainPiece.java
+++ b/src/main/java/org/betterx/betterend/world/structures/piece/CrystalMountainPiece.java
@@ -55,6 +55,7 @@ public class CrystalMountainPiece extends MountainPiece {
             ChunkPos chunkPos,
             BlockPos blockPos
     ) {
+        preloadHeightmap(world, 12);
         final MutableBlockPos pos = GlobalState.stateForThread().POS;
         ChunkAccess chunk = world.getChunk(chunkPos.x, chunkPos.z);
         Heightmap map = chunk.getOrCreateHeightmapUnprimed(Types.WORLD_SURFACE);

--- a/src/main/java/org/betterx/betterend/world/structures/piece/LakePiece.java
+++ b/src/main/java/org/betterx/betterend/world/structures/piece/LakePiece.java
@@ -310,10 +310,6 @@ public class LakePiece extends BasePiece {
         return Mth.clamp(height, 0, 1);
     }
 
-    private long getCacheKey(BlockPos pos) {
-        return (((long) pos.getX()) << 32) ^ (pos.getZ() & 0xFFFFFFFFL);
-    }
-
     private void makeBoundingBox() {
         int minX = MHelper.floor(center.getX() - radius - 8);
         int minY = MHelper.floor(center.getY() - depth - 8);

--- a/src/main/java/org/betterx/betterend/world/structures/piece/LakePiece.java
+++ b/src/main/java/org/betterx/betterend/world/structures/piece/LakePiece.java
@@ -40,7 +40,8 @@ import java.util.Map;
 public class LakePiece extends BasePiece {
     private static final BlockState ENDSTONE = Blocks.END_STONE.defaultBlockState();
     private static final BlockState WATER = Blocks.WATER.defaultBlockState();
-    private final Map<Integer, Byte> heightmap = Maps.newConcurrentMap();
+    private final Map<Long, Byte> heightmap = Maps.newConcurrentMap();
+    private volatile boolean heightmapPreloaded;
     private OpenSimplexNoise noise;
     private BlockPos center;
     private float radius;
@@ -97,6 +98,7 @@ public class LakePiece extends BasePiece {
             ChunkPos chunkPos,
             BlockPos blockPos
     ) {
+        preloadHeightmap(world, 8);
         int minY = this.boundingBox.minY();
         int maxY = this.boundingBox.maxY();
         int sx = SectionPos.sectionToBlockCoord(chunkPos.x);
@@ -239,27 +241,55 @@ public class LakePiece extends BasePiece {
     }
 
     private int getHeight(WorldGenLevel world, BlockPos pos) {
-        int p = ((pos.getX() & 2047) << 11) | (pos.getZ() & 2047);
-        int h = heightmap.getOrDefault(p, Byte.MIN_VALUE);
-        if (h > Byte.MIN_VALUE) {
-            return h;
+        long p = getCacheKey(pos);
+        Byte cached = heightmap.get(p);
+        if (cached != null) {
+            return cached;
         }
 
+        byte h;
         if (!world.getBiome(pos).is(biomeID)) {
-            heightmap.put(p, (byte) 0);
-            return 0;
+            h = 0;
+            Byte previous = heightmap.putIfAbsent(p, h);
+            return previous == null ? h : previous;
         }
 
-        h = world.getHeight(Types.WORLD_SURFACE_WG, pos.getX(), pos.getZ());
-        h = Mth.abs(h - center.getY());
-        h = h < 8 ? 1 : 0;
+        int height = world.getHeight(Types.WORLD_SURFACE_WG, pos.getX(), pos.getZ());
+        height = Mth.abs(height - center.getY());
+        h = (byte) (height < 8 ? 1 : 0);
 
-        heightmap.put(p, (byte) h);
-        return h;
+        Byte previous = heightmap.putIfAbsent(p, h);
+        return previous == null ? h : previous;
+    }
+
+    private void preloadHeightmap(WorldGenLevel world, int clampRadius) {
+        if (heightmapPreloaded) {
+            return;
+        }
+        synchronized (heightmap) {
+            if (heightmapPreloaded) {
+                return;
+            }
+            MutableBlockPos mut = new MutableBlockPos();
+            int minX = boundingBox.minX() - clampRadius;
+            int maxX = boundingBox.maxX() + clampRadius;
+            int minZ = boundingBox.minZ() - clampRadius;
+            int maxZ = boundingBox.maxZ() + clampRadius;
+            mut.setY(center.getY());
+            for (int x = minX; x <= maxX; x++) {
+                mut.setX(x);
+                for (int z = minZ; z <= maxZ; z++) {
+                    mut.setZ(z);
+                    getHeight(world, mut);
+                }
+            }
+            heightmapPreloaded = true;
+        }
     }
 
     private float getHeightClamp(WorldGenLevel world, int radius, int posX, int posZ) {
         MutableBlockPos mut = new MutableBlockPos();
+        mut.setY(center.getY());
         int r2 = radius * radius;
         float height = 0;
         float max = 0;
@@ -280,6 +310,10 @@ public class LakePiece extends BasePiece {
         return Mth.clamp(height, 0, 1);
     }
 
+    private long getCacheKey(BlockPos pos) {
+        return (((long) pos.getX()) << 32) ^ (pos.getZ() & 0xFFFFFFFFL);
+    }
+
     private void makeBoundingBox() {
         int minX = MHelper.floor(center.getX() - radius - 8);
         int minY = MHelper.floor(center.getY() - depth - 8);
@@ -288,5 +322,9 @@ public class LakePiece extends BasePiece {
         int maxY = MHelper.floor(center.getY() + depth);
         int maxZ = MHelper.floor(center.getZ() + radius + 8);
         this.boundingBox = new BoundingBox(minX, minY, minZ, maxX, maxY, maxZ);
+    }
+
+    private long getCacheKey(BlockPos pos) {
+        return (((long) pos.getX()) << 32) ^ (pos.getZ() & 0xFFFFFFFFL);
     }
 }

--- a/src/main/java/org/betterx/betterend/world/structures/piece/MountainPiece.java
+++ b/src/main/java/org/betterx/betterend/world/structures/piece/MountainPiece.java
@@ -24,7 +24,8 @@ import com.google.common.collect.Maps;
 import java.util.Map;
 
 public abstract class MountainPiece extends BasePiece {
-    protected Map<Integer, Integer> heightmap = Maps.newConcurrentMap();
+    protected Map<Long, Integer> heightmap = Maps.newConcurrentMap();
+    private volatile boolean heightmapPreloaded;
     protected OpenSimplexNoise noise1;
     protected OpenSimplexNoise noise2;
     protected BlockPos center;
@@ -85,22 +86,24 @@ public abstract class MountainPiece extends BasePiece {
     }
 
     private int getHeight(WorldGenLevel world, BlockPos pos) {
-        int p = ((pos.getX() & 2047) << 11) | (pos.getZ() & 2047);
-        int h = heightmap.getOrDefault(p, Integer.MIN_VALUE);
-        if (h > Integer.MIN_VALUE) {
-            return h;
+        long p = getCacheKey(pos);
+        Integer cached = heightmap.get(p);
+        if (cached != null) {
+            return cached;
         }
 
+        int h;
         if (!world.getBiome(pos).is(biomeID)) {
-            heightmap.put(p, -10);
-            return -10;
+            h = -10;
+            Integer previous = heightmap.putIfAbsent(p, h);
+            return previous == null ? h : previous;
         }
         h = world.getHeight(Types.WORLD_SURFACE_WG, pos.getX(), pos.getZ());
         h = Mth.abs(h - center.getY());
         if (h > 4) {
             h = 4 - h;
-            heightmap.put(p, h);
-            return h;
+            Integer previous = heightmap.putIfAbsent(p, h);
+            return previous == null ? h : previous;
         }
 
         h = MHelper.floor(noise2.eval(pos.getX() * 0.01, pos.getZ() * 0.01) * noise2.eval(
@@ -109,17 +112,43 @@ public abstract class MountainPiece extends BasePiece {
         ) * 8 + 8);
 
         if (h < 0) {
-            heightmap.put(p, 0);
-            return 0;
+            h = 0;
+            Integer previous = heightmap.putIfAbsent(p, h);
+            return previous == null ? h : previous;
         }
 
-        heightmap.put(p, h);
+        Integer previous = heightmap.putIfAbsent(p, h);
+        return previous == null ? h : previous;
+    }
 
-        return h;
+    protected void preloadHeightmap(WorldGenLevel world, int clampRadius) {
+        if (heightmapPreloaded) {
+            return;
+        }
+        synchronized (heightmap) {
+            if (heightmapPreloaded) {
+                return;
+            }
+            MutableBlockPos mut = new MutableBlockPos();
+            int minX = boundingBox.minX() - clampRadius;
+            int maxX = boundingBox.maxX() + clampRadius;
+            int minZ = boundingBox.minZ() - clampRadius;
+            int maxZ = boundingBox.maxZ() + clampRadius;
+            mut.setY(center.getY());
+            for (int x = minX; x <= maxX; x++) {
+                mut.setX(x);
+                for (int z = minZ; z <= maxZ; z++) {
+                    mut.setZ(z);
+                    getHeight(world, mut);
+                }
+            }
+            heightmapPreloaded = true;
+        }
     }
 
     protected float getHeightClamp(WorldGenLevel world, int radius, int posX, int posZ) {
         MutableBlockPos mut = new MutableBlockPos();
+        mut.setY(center.getY());
         float height = 0;
         float max = 0;
         for (int x = -radius; x <= radius; x++) {
@@ -137,6 +166,10 @@ public abstract class MountainPiece extends BasePiece {
         }
         height /= max;
         return Mth.clamp(height / radius, 0, 1);
+    }
+
+    private long getCacheKey(BlockPos pos) {
+        return (((long) pos.getX()) << 32) ^ (pos.getZ() & 0xFFFFFFFFL);
     }
 
     private void makeBoundingBox() {

--- a/src/main/java/org/betterx/betterend/world/structures/piece/PaintedMountainPiece.java
+++ b/src/main/java/org/betterx/betterend/world/structures/piece/PaintedMountainPiece.java
@@ -76,6 +76,7 @@ public class PaintedMountainPiece extends MountainPiece {
             ChunkPos chunkPos,
             BlockPos blockPos
     ) {
+        preloadHeightmap(world, 10);
         int sx = chunkPos.getMinBlockX();
         int sz = chunkPos.getMinBlockZ();
         final MutableBlockPos pos = GlobalState.stateForThread().POS;


### PR DESCRIPTION
## Summary
- make mountain/lake heightmap caches use full-coordinate keys and deterministic preloading before per-chunk placement
- remove shared mutable SDF/noise state from several BetterEnd worldgen features so placements do not race under threaded generation
- preserve the target C2ME config assumption: EndBiomeCache disabled; this is not intended to prioritize enabled EndBiomeCache support

## Notes
- This follows up on PR #28, which made the maps concurrent but left cache key collisions and other shared mutable worldgen state.
- Local Gradle validation is still pending: the workspace Gradle run stalled in filesystem/input hashing before reaching a useful Java diagnostic. The source delta has been reviewed and the branch is intentionally draft until validation is completed.